### PR TITLE
Unstuck anims

### DIFF
--- a/cfgFunctions.hpp
+++ b/cfgFunctions.hpp
@@ -115,6 +115,7 @@ class grad_civs {
         class sm_business_state_chat_exit {};
         class sm_business_state_chat_loop {};
         class sm_business_state_housework_enter {};
+        class sm_business_state_housework_exit {};
         class sm_business_state_meetNeighbor_enter {};
         class sm_business_state_meetNeighbor_exit {};
         class sm_business_state_meetNeighbor_loop {};

--- a/functions/init/fn_initModule.sqf
+++ b/functions/init/fn_initModule.sqf
@@ -7,6 +7,15 @@ GRAD_CIVS_INITIALIZED = true;
 
 INFO("running full grad-civs initialization now...");
 
+
+// switchMove locality workaround
+[
+    QGVAR(switchMove), {
+        params ["_unit", "_animation"];
+        _unit switchMove _animation;
+    }
+] call CBA_fnc_addEventHandler;
+
 [] call grad_civs_fnc_initConfig;
 [] call grad_civs_fnc_initServer;
 [] call grad_civs_fnc_initHCs;

--- a/functions/sm_activities/fn_sm_activities.sqf
+++ b/functions/sm_activities/fn_sm_activities.sqf
@@ -1,3 +1,4 @@
+#include "..\..\component.hpp"
 
 private _activities = [[], true] call CBA_statemachine_fnc_create;
 private _business = [] call grad_civs_fnc_sm_business;
@@ -120,7 +121,7 @@ assert ([
     _act_panic, _act_business,
     ["grad_civs_panicking_end"],
     {true},
-    {_this switchMove ""},
+    {[QGVAR(switchMove), [_this, ""]] call CBA_fnc_globalEvent;},
     _act_panic + _act_business
 ] call CBA_statemachine_fnc_addEventTransition);
 

--- a/functions/sm_activities/fn_sm_activities_state_panic_enter.sqf
+++ b/functions/sm_activities/fn_sm_activities_state_panic_enter.sqf
@@ -1,3 +1,5 @@
+#include "..\..\component.hpp"
+
 _this enableDynamicSimulation false; // prevent from freezing mid-flight (?)
-_this switchMove ""; // leave everything
+[QGVAR(switchMove), [_this, ""]] call CBA_fnc_globalEvent; // leave everything
 _this forceSpeed -1;

--- a/functions/sm_business/fn_sm_business.sqf
+++ b/functions/sm_business/fn_sm_business.sqf
@@ -61,7 +61,7 @@ private _bus_housework = [
     _business,
     {},
     { _this call grad_civs_fnc_sm_business_state_housework_enter },
-    {},
+    { _this call grad_civs_fnc_sm_business_state_housework_exit },
     "bus_housework"
 ] call grad_civs_fnc_addState;
 

--- a/functions/sm_business/fn_sm_business_state_housework_enter.sqf
+++ b/functions/sm_business/fn_sm_business_state_housework_enter.sqf
@@ -1,3 +1,5 @@
+#include "..\..\component.hpp"
+
 private _house = _this getVariable ["grad_civs_home", objNull];
 _this setVariable ["grad_civs_housework_time", random [5, 15, 120]];
 _this call grad_civs_fnc_forceBusinessSpeed;
@@ -5,7 +7,7 @@ _this call grad_civs_fnc_forceBusinessSpeed;
 if (isNull _house) exitWith {};
 
 if (random 4 > 1) then { // in 2 of 3 cases , do change position
-    _this switchMove "";
+    [QGVAR(switchMove), [_this, ""]] call CBA_fnc_globalEvent;
     doStop _this;
 
     // add one random really close position to house positions
@@ -16,7 +18,8 @@ if (random 4 > 1) then { // in 2 of 3 cases , do change position
 
     _this moveTo _pos;
 } else {
-    _this switchMove selectRandom ["Acts_B_M05_briefing", "Acts_JetsOfficerSpilling", "acts_miller_knockout", "InBaseMoves_HandsBehindBack1"];
+    private _anim = selectRandom ["Acts_B_M05_briefing", "Acts_JetsOfficerSpilling", "acts_miller_knockout", "InBaseMoves_HandsBehindBack1"];
+    [QGVAR(switchMove), [_this, _anim]] call CBA_fnc_globalEvent;
 };
 
 /*

--- a/functions/sm_business/fn_sm_business_state_housework_exit.sqf
+++ b/functions/sm_business/fn_sm_business_state_housework_exit.sqf
@@ -1,1 +1,3 @@
-_this switchMove "";
+#include "..\..\component.hpp"
+
+[QGVAR(switchMove), [_this, ""]] call CBA_fnc_globalEvent;

--- a/functions/sm_business/fn_sm_business_state_housework_exit.sqf
+++ b/functions/sm_business/fn_sm_business_state_housework_exit.sqf
@@ -1,0 +1,1 @@
+_this switchMove "";

--- a/functions/sm_business/fn_sm_business_state_meetNeighbor_enter.sqf
+++ b/functions/sm_business/fn_sm_business_state_meetNeighbor_enter.sqf
@@ -1,6 +1,6 @@
 #include "..\..\component.hpp"
 
-_this switchMove "";
+[QGVAR(switchMove), [_this, ""]] call CBA_fnc_globalEvent;
 doStop _this;
 _this setVariable ["grad_civs_stopDistance", random [3, 7, 20]];
 private _neighborToMeet = _this getVariable ["grad_civs_neighborToMeet", objNull];

--- a/functions/sm_lifecycle/fn_sm_lifecycle_state_spawn_enter.sqf
+++ b/functions/sm_lifecycle/fn_sm_lifecycle_state_spawn_enter.sqf
@@ -58,7 +58,7 @@ private _addKilledNews = {
 
 		_unit removeAllEventHandlers "Killed";
 		_unit removeAllEventHandlers "FiredNear";
-		_unit switchMove "";
+		[QGVAR(switchMove), [_unit, ""]] call CBA_fnc_globalEvent;
     }];
 };
 

--- a/functions/spawn/fn_serverLoop.sqf
+++ b/functions/spawn/fn_serverLoop.sqf
@@ -43,8 +43,18 @@ grad_civs_debugLoop = [{
 [
     {
         GRAD_CIVS_LOCAL_CIVS = GRAD_CIVS_LOCAL_CIVS select {
-            !(isNull _x)
-        }
+            if (isNull _x) then {
+                INFO_1("abandoning civilian they have become NULL (deleted?)", _x);
+                false
+            } else {
+                if (local _x) then {
+                    true
+                } else {
+                    WARNING_1("abandoning civilian %1 as they are not local any more", _x);
+                    false
+                };
+            };
+        };
     },
     5,
     []


### PR DESCRIPTION
* add `switchMove ""` on household exit
* execute all `switchMove globally` [just like ZEN is doing](https://github.com/zen-mod/ZEN/blob/906f462b8c3f7868444e5731cfe6546ce8451abb/addons/modules/functions/fnc_moduleAmbientAnimEnd.sqf#L45)
* take care to remove non-local civs from grad-civs control
* log non-local and NULL civs