### PR TITLE
Custom behavior events

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,22 @@ class CfgGradCivs {
 };
 ```
 
+## Events
+
+### custom activity
+
+To let civilians break from their usual activity and do something else, you can use events:
+
+This will make the civilian available to be given custom commands without interference from grad-civs:
+
+`["GRAD_civs_customActivity_start", [_civ], _civ] call CBA_fnc_targetEvent;`
+
+To end the custom activity and make the civ resume their normal stuff, fire another event:
+
+`["GRAD_civs_customActivity_end", [_civ], _civ] call CBA_fnc_targetEvent;`
+
+**NOTE**: this whole thing will *NOT* work while they are panicking.
+
 ## Functions
 
 All functions meant for use from outside sit in the `/functions/api` directory.

--- a/cfgFunctions.hpp
+++ b/cfgFunctions.hpp
@@ -51,9 +51,11 @@ class grad_civs {
         class findPositionOfInterest {};
         class findRandomPos {};
         class findRandomPosArea {};
+        class formatNowPlusSeconds {};
         class getCurrentState {};
         class getGlobalCivs {};
         class isInHouse {};
+        class nowPlusSeconds {};
         class removeFromStateMachine {};
     };
 
@@ -96,12 +98,10 @@ class grad_civs {
         class sm_activities_helper_surrenderCondition {};
         class sm_activities_state_asOrdered_enter {};
         class sm_activities_state_asOrdered_exit {};
-        class sm_activities_state_asOrdered_loop {};
         class sm_activities_state_panic_enter {};
         class sm_activities_state_panic_exit {};
         class sm_activities_state_surrendered_enter {};
         class sm_activities_state_surrendered_exit {};
-        class sm_activities_trans_asOrdered_business_condition {};
         class sm_activities_trans_business_panic_condition {};
         class sm_activities_trans_business_surrendered_condition {};
         // class sm_activities_trans_panic_business_condition {}; // event transition

--- a/docs/states.gv
+++ b/docs/states.gv
@@ -50,7 +50,7 @@ digraph lifecycle {
 
             act_surrendered -> cluster_business_node [lhead=cluster_business];
             cluster_business_node -> act_surrendered [ltail=cluster_business];
-            act_asOrdered -> cluster_business_node [lhead=cluster_business];
+            act_asOrdered -> cluster_business_node [lhead=cluster_business color=red];
             cluster_business_node -> act_asOrdered [ltail=cluster_business color=red];
 
             cluster_panic_node -> cluster_business_node [color=blue lhead=cluster_business ltail=cluster_panic]

--- a/functions/common/fn_formatNowPlusSeconds.sqf
+++ b/functions/common/fn_formatNowPlusSeconds.sqf
@@ -1,0 +1,5 @@
+#include "..\..\component.hpp"
+
+private _seconds = _this;
+private _date = _seconds call FUNC(nowPlusSeconds);
+([_date] call BIS_fnc_timeToString)

--- a/functions/common/fn_nowPlusSeconds.sqf
+++ b/functions/common/fn_nowPlusSeconds.sqf
@@ -1,0 +1,2 @@
+private _seconds = _this;
+(daytime + (_seconds / 3600))

--- a/functions/sm_activities/fn_sm_activities_state_asOrdered_enter.sqf
+++ b/functions/sm_activities/fn_sm_activities_state_asOrdered_enter.sqf
@@ -1,6 +1,3 @@
-if (_this getVariable ["grad_civs_act_leave_state_time", 0] < CBA_missionTime) then {
-    private _recklessness = _this getVariable ["grad_civs_recklessness", 5];
-    private _waitTime = linearConversion [0, 10, _recklessness, 180, 15, false];
+#include "..\..\component.hpp";
 
-    _this setVariable ["grad_civs_act_leave_state_time", CBA_missionTime + _waitTime];
-};
+LOG_1("%1 entering ordered state", _this)

--- a/functions/sm_activities/fn_sm_activities_state_asOrdered_loop.sqf
+++ b/functions/sm_activities/fn_sm_activities_state_asOrdered_loop.sqf
@@ -1,2 +1,0 @@
-private _delay = (_this getVariable ["grad_civs_act_leave_state_time", 0]) - CBA_missionTime;
-[_this, format ["will leave this ordered state in  %1s", _delay]] call grad_civs_fnc_setCurrentlyThinking;

--- a/functions/sm_activities/fn_sm_activities_trans_asOrdered_business_condition.sqf
+++ b/functions/sm_activities/fn_sm_activities_trans_asOrdered_business_condition.sqf
@@ -1,1 +1,0 @@
-CBA_missionTime - (_this getVariable ["grad_civs_act_leave_state_time", 0]) > 0

--- a/functions/sm_business/fn_sm_business_trans_rally_housework_condition.sqf
+++ b/functions/sm_business/fn_sm_business_trans_rally_housework_condition.sqf
@@ -1,1 +1,1 @@
-_this getVariable ["grad_civs_primaryTask", ""] == "reside"
+(_this getVariable ["grad_civs_primaryTask", ""]) == "reside"


### PR DESCRIPTION
* add custom events `GRAD_civs_customActivity_start`  and `GRAD_civs_customActivity_end` to enable missionmakers to temporarily insert custom behavior:

```markdown
### custom activity

To let civilians break from their usual activity and do something else, you can use events:

This will make the civilian available to be given custom commands without interference from grad-civs:

`["GRAD_civs_customActivity_start", [_civ], _civ] call CBA_fnc_targetEvent;`

To end the custom activity and make the civ resume their normal stuff, fire another event:

`["GRAD_civs_customActivity_end", [_civ], _civ] call CBA_fnc_targetEvent;`

**NOTE**: this whole thing will *NOT* work while they are panicking.
```

* adjust cooldown times for "send away", "get down", "honked at" behavior