### PR TITLE
optimization & bugfixes

### DIFF
--- a/functions/common/fn_findBuildings.sqf
+++ b/functions/common/fn_findBuildings.sqf
@@ -2,40 +2,10 @@
 
 params [
 	["_searchPos", [0, 0, 0]],
-	["_radius", 0],
-	["_minPosCount", 1]
+	["_radius", 0]
 ];
 
 if (_searchPos isEqualTo [0, 0, 0]) exitWith {ERROR_1("invalid usage, _searchPos is Origin");[]};
 if (_radius isEqualTo 0) exitWith {ERROR_1("invalid usage, _radius is %1", _radius);[]};
 
-//exclusion list for houses
-private _exclusionList = [
-	"Land_Pier_F",
-	"Land_Pier_small_F",
-	"Land_NavigLight",
-	"Land_LampHarbour_F",
-	"Land_runway_edgelight"
-];
-
-//HOUSE LIST ===================================================================
-_houseList = _searchPos nearObjects ["House", _radius];
-LOG_3("%1 houses within %2m of %3, will whittle down by positions and excluded types", count _houseList, _radius, _searchPos);
-//Clean up house list (remove buildings that have no positions)
-_cleanUpCounter = 0;
-{
-	SCRIPT("findBuildings_filter");
-	//_buildingPos = _x buildingPos 0;
-	//if ((str _buildingPos) == "[0,0,0]") then {
-	if (count (_x buildingPos -1) < _minPosCount) then {
-			_houseList = _houseList - [_x];
-			_cleanUpCounter = _cleanUpCounter + 1;
-	} else {
-        if (typeOf _x in _exclusionList) then {
-            _houseList = _houseList - [_x];
-            _cleanUpCounter = _cleanUpCounter + 1;
-        };
-    };
-} forEach _houseList;
-
-_houseList
+_searchPos nearObjects ["House", _radius];

--- a/functions/common/fn_isInHouse.sqf
+++ b/functions/common/fn_isInHouse.sqf
@@ -1,8 +1,14 @@
 // originall written by KK
 
+
+private _pos = _this;
+if (_this isEqualType objNull) then {
+    _pos = getPosASL _this;
+};
+
 lineIntersectsSurfaces [
-    _this,
-	_this vectorAdd [0, 0, 50],
+    _pos,
+	_pos vectorAdd [0, 0, 50],
 	objNull,
     objNull,
     true,

--- a/functions/common/fn_isInPopulatedZone.sqf
+++ b/functions/common/fn_isInPopulatedZone.sqf
@@ -4,6 +4,8 @@ params [
     ["_position", [0, 0, 0]]
 ];
 
+assert(_position isEqualType []);
+
 private _inAnyPopulationZone = if (count GVAR(POPULATION_ZONES) == 0) then {
     true
 } else {

--- a/functions/init/fn_initConfig.sqf
+++ b/functions/init/fn_initConfig.sqf
@@ -49,7 +49,7 @@ missionNamespace setVariable ["GRAD_CIVS_ONHELDUP",compile ([missionConfigFile >
 missionNamespace setVariable ["GRAD_CIVS_ONKILLED",compile ([missionConfigFile >> "cfgGradCivs","onKilled",""] call BIS_fnc_returnConfigEntry)];
 
 _initialGroupSize = [missionConfigFile >> "cfgGradCivs","initialGroupSize", 3] call BIS_fnc_returnConfigEntry;
-if (typeName _initialGroupSize == "NUMBER") then { _initialGroupSize = _initialGroupSize + 1 };
+if (typeName _initialGroupSize == "SCALAR") then { _initialGroupSize = _initialGroupSize + 1 };
 missionNamespace setVariable ["GRAD_CIVS_INITIALGROUPSIZE", _initialGroupSize];
 missionNamespace setVariable ["GRAD_CIVS_AUTOMATICVEHICLEGROUPSIZE", ([missionConfigFile >> "cfgGradCivs","automaticVehicleGroupSize", 1] call BIS_fnc_returnConfigEntry) == 1];
 missionNamespace setVariable ["GRAD_CIVS_PANICCOOLDOWN", ([missionConfigFile >> "cfgGradCivs", "panicCooldown", [15, 120, 240]] call BIS_fnc_returnConfigEntry)];

--- a/functions/sm_lifecycle/fn_sm_lifecycle_trans_life_despawn_condition.sqf
+++ b/functions/sm_lifecycle/fn_sm_lifecycle_trans_life_despawn_condition.sqf
@@ -1,4 +1,6 @@
-private _idx =  GRAD_CIVS_LOCAL_CIVS find _this;
+#include "..\..\component.hpp"
+
+private _idx =  GVAR(LOCAL_CIVS) find _this;
 
 if (_idx == -1) exitWith {false}; // should not happen, really
 
@@ -6,12 +8,12 @@ if (((floor CBA_missionTime) mod 10) != (_idx mod 10)) exitWith {false}; // chec
 
 if (_this getVariable ["grad_civs_excludeFromCleanup",false]) exitWith {false};
 
-private _cleanupDistance = GRAD_CIVS_SPAWNDISTANCEINVEHICLESMAX * 1.2;
-if (isNull (_this call grad_civs_fnc_getGroupVehicle)) then {
-    _cleanupDistance = GRAD_CIVS_SPAWNDISTANCEONFOOTMAX * 1.5;
+private _cleanupDistance = GVAR(SPAWNDISTANCEINVEHICLESMAX) * 1.2;
+if (isNull (_this call FUNC(getGroupVehicle))) then {
+    _cleanupDistance = GVAR(SPAWNDISTANCEONFOOTMAX) * 1.5;
 };
-if (_this distance nearestBuilding _this < 3) then {
-    _cleanupDistance = GRAD_CIVS_SPAWNDISTANCERESIDENTMAX * 1.2;
+if (_this call FUNC(isInHouse)) then {
+    _cleanupDistance = GVAR(SPAWNDISTANCERESIDENTMAX) * 1.2;
 };
 
 private _playersAreClose = true isEqualTo ({

--- a/functions/spawn/fn_addResident.sqf
+++ b/functions/spawn/fn_addResident.sqf
@@ -16,7 +16,7 @@ if (isNull _house) exitWith {LOG("could not find spawn position for resident thi
 
 private _groupSize = floor random GRAD_CIVS_INITIALGROUPSIZE;
 
-private _group = [getPos _house, _groupSize, objNull, _house, "reside"] call grad_civs_fnc_spawnCivilianGroup;
+private _group = [getPos _house, _groupSize, objNull, _house, "reside"] call FUNC(spawnCivilianGroup);
 if (isNull _group) exitWith {};
 
 _group

--- a/functions/spawn/fn_findSpawnPosition.sqf
+++ b/functions/spawn/fn_findSpawnPosition.sqf
@@ -54,10 +54,10 @@ private _result = {
         if ((!(isNull _candidate))
             && {
                 LOG_3("_allPlayers: %1, _candidate %2, _minDistance %3", _allPlayers, getPos _candidate, _minDistance);
-                [_allPlayers, _candidate, _minDistance] call grad_civs_fnc_isInDistanceFromOtherPlayers
+                [_allPlayers, _candidate, _minDistance] call FUNC(isInDistanceFromOtherPlayers)
             }
             && {
-                [_candidate] call FUNC(isInPopulatedZone)
+                [getPos _candidate] call FUNC(isInPopulatedZone)
             }
         ) exitWith {
             LOG_1("found spawn position %1", _candidate);

--- a/functions/spawn/fn_findUnclaimedHouse.sqf
+++ b/functions/spawn/fn_findUnclaimedHouse.sqf
@@ -24,16 +24,31 @@ private _exclusionList = [
     "gm_structure_euro_80_wall_base"
 ];
 
+/*
+private _exclusionPrefixList = [
+    "land_gm_fence"
+];
+*/
+
+
 private _minPosCount = 2;
 
 LOG_3("%1 houses within %2m of %3, will whittle down by positions and excluded types", count _houses, _radius, _position);
 
 private _idx = _houses findIf {
-    private _isUnoccupied = (count (_x getVariable ["grad_civs_residents", []])) == 0;
-    private _hasEnoughPositions = (count (_x buildingPos -1)) >= _minPosCount;
+    // assumprions:
+    // a) there will be many more houses than civs - hence, occupation filter should come last
+    // b) there are many unsuited house types, and their number will grow (heck even *fences* can be of type "house") - good filter, comes first
+
+    private _isUnoccupied = {
+        (count (_x getVariable ["grad_civs_residents", []])) == 0;
+    };
+    private _hasEnoughPositions = {
+        (count (_x buildingPos -1)) >= _minPosCount;
+    };
     private _goodHouseType = !((typeOf _x) in _exclusionList);
 
-    _isUnoccupied && _hasEnoughPositions && _goodHouseType
+    _goodHouseType && _hasEnoughPositions && _isUnoccupied
 };
 
 if (_idx != -1) then {

--- a/functions/spawn/fn_findUnclaimedHouse.sqf
+++ b/functions/spawn/fn_findUnclaimedHouse.sqf
@@ -20,7 +20,8 @@ private _exclusionList = [
 	"Land_Pier_small_F",
 	"Land_NavigLight",
 	"Land_LampHarbour_F",
-	"Land_runway_edgelight"
+	"Land_runway_edgelight",
+    "gm_structure_euro_80_wall_base"
 ];
 
 private _minPosCount = 2;

--- a/functions/spawn/fn_findUnclaimedHouse.sqf
+++ b/functions/spawn/fn_findUnclaimedHouse.sqf
@@ -9,18 +9,34 @@ params [
 
 LOG_2("looking for unclaimed house at %1 within %2 m", _position, _radius);
 
-private _houses = [_position, _radius, 2] call grad_civs_fnc_findBuildings;
+private _houses = [
+    _position,
+    _radius
+] call grad_civs_fnc_findBuildings;
 
-LOG_1("_houses found initially: %1", _houses);
+//exclusion list for houses
+private _exclusionList = [
+	"Land_Pier_F",
+	"Land_Pier_small_F",
+	"Land_NavigLight",
+	"Land_LampHarbour_F",
+	"Land_runway_edgelight"
+];
 
-_houses = _houses select {
-    (count (_x getVariable ["grad_civs_residents", []])) == 0
+private _minPosCount = 2;
+
+LOG_3("%1 houses within %2m of %3, will whittle down by positions and excluded types", count _houses, _radius, _position);
+
+private _idx = _houses findIf {
+    private _isUnoccupied = (count (_x getVariable ["grad_civs_residents", []])) == 0;
+    private _hasEnoughPositions = (count (_x buildingPos -1)) >= _minPosCount;
+    private _goodHouseType = !((typeOf _x) in _exclusionList);
+
+    _isUnoccupied && _hasEnoughPositions && _goodHouseType
 };
 
-LOG_1("_houses found unclaimed: %1", _houses);
-
-if (count _houses > 0) then {
-    selectRandom _houses
+if (_idx != -1) then {
+    _houses select _idx
 } else {
     objNull
 }


### PR DESCRIPTION
* optimize finding house ("find first"  instead of "filter all then select random")
* config bugfix : setting group size as single value was off by one (1 led to 0-size groups, welp)
* some of macro usage
* start filter for unsuitable gm houses (like... fences -.-)

~~TODO: test with vehicles / high distances~~

löppt.

on a test on Weferlingen with 
`spawnDistancesInVehicles[] = {1500,2500};` spawning a group of abt 6 civs took 36ms with an according frametime jump. (hence: do use HC!) . waypoint planning was faster.
