### PR TITLE
add exclusion zone via zeus module

### DIFF
--- a/cfgFunctions.hpp
+++ b/cfgFunctions.hpp
@@ -91,6 +91,7 @@ class grad_civs {
         class isPlayerHonking {};
         class playerLoop {};
         class registerAceInteractionHandler {};
+        class setupZeusModules {};
         class showCivHint {};
     };
 

--- a/functions/api/fn_addExclusionZone.sqf
+++ b/functions/api/fn_addExclusionZone.sqf
@@ -1,13 +1,7 @@
 #include "..\..\component.hpp"
 
-_this params [
-    ["_trigger", objNull]
-];
+params ["_area"];
 
-if (isNull _trigger) exitWith {
-    ERROR("got NULL instead of a trigger as parameter");
-};
+GVAR(EXCLUSION_ZONES) pushBackUnique _area;
 
-GVAR(EXCLUSION_ZONES) pushBack _trigger;
-
-INFO_2("added exclusion zone %1 at %2", triggerArea _trigger, getPos _trigger);
+INFO_1("added exclusion zone %1", _area);

--- a/functions/api/fn_addPopulationZone.sqf
+++ b/functions/api/fn_addPopulationZone.sqf
@@ -1,13 +1,7 @@
 #include "..\..\component.hpp"
 
-_this params [
-    ["_trigger", objNull]
-];
+params ["_area"];
 
-if (isNull _trigger) exitWith {
-    ERROR("got NULL instead of a trigger as parameter");
-};
+GVAR(POPULATION_ZONES) pushBack _area;
 
-GVAR(POPULATION_ZONES) pushBack _trigger;
-
-INFO_2("added population zone %1 at %2", triggerArea _trigger, getPos _trigger);
+INFO_1("added population zone %1", _area);

--- a/functions/init/fn_initPlayer.sqf
+++ b/functions/init/fn_initPlayer.sqf
@@ -6,13 +6,15 @@ params [
 if (_mode == "postInit" && {([missionConfigFile >> "cfgGradCivs", "autoInit", 0] call BIS_fnc_returnConfigEntry) != 1}) exitWith {INFO("autoInit disabled, not running initPlayer right now...")};
 
 if (hasInterface) then {
-    if (isNil "GRAD_CIVS_DEBUG_CIVSTATE") then {missionNamespace setVariable ["GRAD_CIVS_DEBUG_CIVSTATE",([missionConfigFile >> "cfgGradCivs","debugCivState",0] call BIS_fnc_returnConfigEntry) == 1]};
-    if (isNil "GRAD_CIVS_INFOCHANNEL") then {GRAD_CIVS_INFOCHANNEL = 0;};
+    if (isNil QGVAR(DEBUG_CIVSTATE)) then {missionNamespace setVariable [QGVAR(DEBUG_CIVSTATE),([missionConfigFile >> "cfgGradCivs","debugCivState",0] call BIS_fnc_returnConfigEntry) == 1]};
+    if (isNil QGVAR(INFOCHANNEL)) then {GRAD_CIVS_INFOCHANNEL = 0;};
 
-    [] call grad_civs_fnc_playerLoop;
-    [] call grad_civs_fnc_registerAceInteractionHandler;
+    [] call FUNC(playerLoop);
+    [] call FUNC(registerAceInteractionHandler);
+    [] call FUNC(setupZeusModules);
     if (GRAD_CIVS_DEBUG_CIVSTATE) then {
-        [] call grad_civs_fnc_showWhatTheyThink;
-        [{!isNull (findDisplay 12)}, {[] call grad_civs_fnc_mapMarkers}, []] call CBA_fnc_waitUntilAndExecute;
+        [] call FUNC(showWhatTheyThink);
+
+        [{!isNull (findDisplay 12)}, {[] call FUNC(mapMarkers)}, []] call CBA_fnc_waitUntilAndExecute;
     };
 };

--- a/functions/player/fn_setupZeusModules.sqf
+++ b/functions/player/fn_setupZeusModules.sqf
@@ -1,0 +1,51 @@
+#include "..\..\component.hpp"
+
+["GRAD-CIVS","ADD EXCLUSION ZONE (click within existing area marker!)",
+    {
+        params [
+            ["_clickPos", [0, 0, 0]]
+        ];
+        private _areaMarkersAtPos = allMapMarkers select {
+            (["RECTANGLE", "ELLIPSE"] find (markerShape _x)) > -1
+        } select {
+            _clickPos inArea _x
+        };
+
+        private _distances = _areaMarkersAtPos apply { (markerPos _x) distance _clickPos };
+        private _minDistanceAndIndex = _distances call CBA_fnc_findMin;
+
+        if (isNil "_minDistanceAndIndex") exitWith {
+            systemChat format["no area marker at position %1", _clickPos];
+        };
+        private _marker = _areaMarkersAtPos select (_minDistanceAndIndex#1);
+
+        [_marker] call FUNC(addExclusionZone);
+        _marker setMarkerBrushLocal "BORDER";
+        _marker setMarkerColorLocal "ColorUNKNOWN";
+    }
+] call zen_custom_modules_fnc_register;
+
+["GRAD-CIVS","ADD POPULATION ZONE (click within existing area marker!)",
+    {
+        params [
+            ["_clickPos", [0, 0, 0]]
+        ];
+        private _areaMarkersAtPos = allMapMarkers select {
+            (["RECTANGLE", "ELLIPSE"] find (markerShape _x)) > -1
+        } select {
+            _clickPos inArea _x
+        };
+
+        private _distances = _areaMarkersAtPos apply { (markerPos _x) distance _clickPos };
+        private _minDistanceAndIndex = _distances call CBA_fnc_findMin;
+
+        if (isNil "_minDistanceAndIndex") exitWith {
+            systemChat format["no area marker at position %1", _clickPos];
+        };
+        private _marker = _areaMarkersAtPos select (_minDistanceAndIndex#1);
+
+        [_marker] call FUNC(addPopulationZone);
+        _marker setMarkerBrushLocal "BORDER";
+        _marker setMarkerColorLocal "ColorCIV";
+    }
+] call zen_custom_modules_fnc_register;

--- a/functions/player/fn_showCivHint.sqf
+++ b/functions/player/fn_showCivHint.sqf
@@ -11,5 +11,5 @@ if (_structured == "") then {
 if (GRAD_CIVS_INFOCHANNEL == 0) then {
     systemChat _plain;
 } else {
-    player customChat [GRAD_CIVS_INFOCHANNEL, _plain] ;
+    player customChat [GRAD_CIVS_INFOCHANNEL, _plain];
 };

--- a/functions/spawn/fn_createInfoChannel.sqf
+++ b/functions/spawn/fn_createInfoChannel.sqf
@@ -1,5 +1,5 @@
 #include "..\..\component.hpp"
 
-ASSERT_SERVER("");
+ASSERT_SERVER("radio channel must be created on server");
 
 radioChannelCreate [[0.96, 0.34, 0.13, 0.8], "grad-civs info", "%CHANNEL_LABEL:", [], true];


### PR DESCRIPTION
depends on ZEN which lets you add area markers as Zeus.

as Zeus
* create area marker using ZEN module (look in "Misc")
* select the GRAD_CIVS "ADD EXCLUSION ZONE" module and click somewher within the area you just created
* DONE! no new civs will spawn in that area or create waypoints there

note: we cannot click *on* the area marker, b/c ZEN has registered the click handler for opening a dialog

_note: as we're storing a reference to the area itself, you can edit the area using ZEN and the exclusion zone will change with it._