### PR TITLE
use animation for checking raised weapon

### DIFF
--- a/functions/player/fn_checkWeaponOnCivilianPointer.sqf
+++ b/functions/player/fn_checkWeaponOnCivilianPointer.sqf
@@ -2,7 +2,14 @@
 
 scopeName "checkPointer_main";
 
-if ((alive player) && (!weaponLowered player) && (vehicle player == player)) then {
+
+// NOTE: we need to use animationState, as !weaponLowered does *not* mean "weaponRaised"
+if (
+    (alive player) &&
+    {!weaponLowered player} &&
+    {vehicle player == player} &&
+    {"sras" in (animationState player)}
+) then {
 
     _currentCiv = player getVariable ["GRAD_isPointingAtObj", objNull];
     _possibleCiv = driver cursorTarget;


### PR DESCRIPTION
As !weaponLowered doers *not* mean "weaponRaised", check player animationState before causing civilian to surrender.

fixes #58 