### PR TITLE
Fix patrol waypoints

### DIFF
--- a/functions/behaviour/fn_taskPatrolFindWaypoint.sqf
+++ b/functions/behaviour/fn_taskPatrolFindWaypoint.sqf
@@ -38,8 +38,8 @@ for "_i" from 1 to _maxTries do {
         _searchPosition
     };
 
-    private _inAnyExclusionZone = [_searchPosition] call FUNC(isInPopulatedZone);
-    if (!_inAnyExclusionZone) exitWith {
+    private _inPopulatedZone = [_searchPosition] call FUNC(isInPopulatedZone);
+    if (_inPopulatedZone) exitWith {
         LOG_1("position %1 is not in exclusionzone, return it", _searchPosition);
         _waypointPosition = _searchPosition;
     };

--- a/functions/behaviour/fn_taskPatrolFindWaypoints.spec.sqf
+++ b/functions/behaviour/fn_taskPatrolFindWaypoints.spec.sqf
@@ -50,3 +50,17 @@
     ],
     grad_civs_fnc_clearExclusionZones
 ] call grad_testing_fnc_executeTest;
+
+["GIVEN a point and no exclusion zones WHEN a patrol path is created",
+    {
+        [([[0, 0, 0], 250, 3] call grad_civs_fnc_taskPatrolFindWaypoints)]
+    },
+    [
+        ["three positions are returned as requested",
+            {
+                params [["_positions", []]];
+                [3, count _positions] call grad_testing_fnc_assertEquals;
+            }
+        ]
+    ]
+] call grad_testing_fnc_executeTest;


### PR DESCRIPTION
if there were no exclusion zones, patrols would not get waypoints (weirdly it *did* work sometimes :tinfoil: )